### PR TITLE
Add sponsors_footer template to base.html

### DIFF
--- a/templates/wafer/base.html
+++ b/templates/wafer/base.html
@@ -25,6 +25,9 @@
 {% endblock %}
           <br clear="all">
         </div>
+        <div id="logos" class="container">
+          {% sponsors_footer %}
+        </div>
         <div id="legal" class="container">
           &copy; 2019 Python Software Society of South Africa.
         </div>


### PR DESCRIPTION
We added the templatetag to make handling the sponsor footer easier, so we should use it.

We wrap it in a div since wafer currently doesn't set the container class in the templatetag - that should probably be fixed at some point.