### PR TITLE
Use ticket type names, rather than DB ids

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -105,19 +105,24 @@ WAFER_MENUS += (
 )
 
 
-def tickets_sold(ticket_type_ids):
+def tickets_sold(ticket_types):
     """ Return number of tickets sold. """
-    from wafer.tickets.models import Ticket
-
+    from wafer.tickets.models import Ticket, TicketType
+    ticket_type_ids = TicketType.objects.filter(name__in=ticket_types)
     return Ticket.objects.filter(type_id__in=ticket_type_ids).count()
 
 
 def main_conference_tickets_sold():
     """ Return number of tickets sold for the main conference. """
-    from wafer.tickets.models import Ticket
+    from wafer.tickets.models import Ticket, TicketType
 
-    TUTORIAL_TICKET_TYPES = []
-    return Ticket.objects.exclude(type_id__in=TUTORIAL_TICKET_TYPES).count()
+    TUTORIAL_TICKET_TYPES = [
+        'Tutorial: "Python for Analysts" (Wednesday, 9 October, 9:00am - 5:30pm)',
+        'Tutorial: "Introduction to Deep Learning" (Wednesday, 9 October, 9:00am - 5:30pm)',
+    ]
+    tutorial_type_ids = TicketType.objects.filter(name__in=TUTORIAL_TICKET_TYPES)
+
+    return Ticket.objects.exclude(type_id__in=tutorial_type_ids).count()
 
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
@@ -136,8 +141,10 @@ MARKITUP_FILTER = (
             "mdx_variables": {
                 "vars": {
                     "main_conference_tickets_sold": main_conference_tickets_sold,
-                    # 'tutorial_data_science_tickets_sold': lambda: tickets_sold([10, 13]),
-                    # 'tutorial_hello_types_tickets_sold': lambda: tickets_sold([9]),
+                    'tutorial_introduction_to_deep_learning_sold':
+                        lambda: tickets_sold(['Tutorial: "Introduction to Deep Learning" (Wednesday, 9 October, 9:00am - 5:30pm)']),
+                    'tutorial_python_for_analysys_tickets_sold':
+                        lambda: tickets_sold(['Tutorial: "Python for Analysts" (Wednesday, 9 October, 9:00am - 5:30pm)']),
                     # 'tutorial_geodjango_foss_gis': lambda: tickets_sold([14]),
                 }
             }


### PR DESCRIPTION
This simplifies adding markdown variables for tickets, and makes things more explicit rather than using somewhat opaque database ids.

We also add the currently open tutorials