### PR TITLE
Add some CSS styling for the highlight-venue option

### DIFF
--- a/static/css/pyconza2019.css
+++ b/static/css/pyconza2019.css
@@ -161,16 +161,6 @@ body {
   text-align: center;
 }
 
-#main table td.schedule-placeholder {
-  background: #e5dada;
-  border: solid 2px #eee7e7;
-  font-style: italic;
-}
-
-#main table td.schedule-placeholder a {
-  color: rgba(0, 38, 66, 0.5);
-}
-
 #main table td.schedule-keynote {
   background: #e5dada;
   background-image: linear-gradient(to left, #e5dada, #a54569);
@@ -183,6 +173,29 @@ body {
   color: #e59500;
   line-height: 26px;
   text-align: center;
+}
+
+#main table th.schedule-highlight-venue {
+   filter: brightness(150%);
+}
+
+#main table td.schedule-highlight-venue a {
+   color: #007060;
+}
+
+/* We unset the highlight-venue effect for breaks using CSS ordering */
+#main table td.schedule-break a {
+  color: #002642;
+}
+
+#main table td.schedule-placeholder {
+  background: #e5dada;
+  border: solid 2px #eee7e7;
+  font-style: italic;
+}
+
+#main table td.schedule-placeholder a {
+  color: rgba(0, 38, 66, 0.5);
 }
 
 #main table td.unavailable a {


### PR DESCRIPTION
This adds some styling so the "schedule?highlight-venue=X" option is at least somewhat visually distinct.

I'm not particularly happy with the text color, but wanted something different but still not too far off our standard palette for it. Better suggestions welcome.

There's also some dependence on the CSS order, which I'm not that happy about, but we can consider better fixes after the conference.
